### PR TITLE
Modify sdp package so that a TTL field is only set when the connection is an ip4 one.

### DIFF
--- a/sdp/sdp.go
+++ b/sdp/sdp.go
@@ -310,6 +310,7 @@ func parseMedia(s string) (Media, error) {
 type ConnInfo struct {
 	Address netip.Addr
 	// TTL is the time-to-live of multicast packets.
+	// This field should only be used for IP4 connections.
 	TTL uint8
 	// Count is the number of subsequent IP addresses after
 	// Address used in the session.

--- a/sdp/sdp.go
+++ b/sdp/sdp.go
@@ -322,7 +322,7 @@ func (c *ConnInfo) String() string {
 		ipv = "IP4"
 	}
 	s := fmt.Sprintf("c=%s %s %s", "IN", ipv, c.Address)
-	if c.TTL > 0 {
+	if c.Address.Is4() && c.TTL > 0 {
 		s += fmt.Sprintf("/%d", c.TTL)
 	}
 	if c.Count > 0 {


### PR DESCRIPTION
As per https://www.rfc-editor.org/rfc/rfc8866.html#section-5.7 the TTL field should only be set on IPv4 connections as IPv6 connections are expected to use [address scoping](https://en.wikipedia.org/wiki/IPv6_address#Address_scopes) instead.